### PR TITLE
ci: add modal deployment step to github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,10 @@ jobs:
 
       - name: Test with pytest
         run: uv run pytest --cov=src/shelly_buienradar --cov-report=xml tests/
+
+      - name: Deploy to Modal
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+        run: uv run modal deploy run_cloud.py


### PR DESCRIPTION
Added a deploy to Modal step that runs `uv run modal deploy run_cloud.py` when code is pushed to `main`. This ensures deployments happen automatically upon successful merges, provided tests pass.

---
*PR created automatically by Jules for task [5973400011751639248](https://jules.google.com/task/5973400011751639248) started by @japppie*