### PR TITLE
Fix deployment script import attribute error with `modal.Mount`

### DIFF
--- a/run_cloud.py
+++ b/run_cloud.py
@@ -5,9 +5,6 @@ import sys
 # Add the src directory to Python's path so it can be imported both locally and inside Modal
 sys.path.insert(0, os.path.abspath("src"))
 
-# Create a mount for the src directory so Modal ships it to the cloud
-src_mount = modal.Mount.from_local_dir("src", remote_path="/root/src")
-
 # Define the Modal app with required packages
 app = modal.App("shelly_automation")
 
@@ -15,8 +12,7 @@ app = modal.App("shelly_automation")
 @app.function(
     secrets=[modal.Secret.from_name("shelly-secret")],
     schedule=modal.Cron("*/6 7-23 * * *"),  # Every 6 minutes between 07:00 and 23:00
-    image=modal.Image.debian_slim().pip_install("requests", "python-dotenv"),
-    mounts=[src_mount],
+    image=modal.Image.debian_slim().pip_install("requests", "python-dotenv").add_local_dir("src", remote_path="/root/src"),
 )
 def scheduled_task():
     # Import inside the function so it doesn't try to load it globally before mounting

--- a/run_cloud.py
+++ b/run_cloud.py
@@ -12,7 +12,9 @@ app = modal.App("shelly_automation")
 @app.function(
     secrets=[modal.Secret.from_name("shelly-secret")],
     schedule=modal.Cron("*/6 7-23 * * *"),  # Every 6 minutes between 07:00 and 23:00
-    image=modal.Image.debian_slim().pip_install("requests", "python-dotenv").add_local_dir("src", remote_path="/root/src"),
+    image=modal.Image.debian_slim()
+    .pip_install("requests", "python-dotenv")
+    .add_local_dir("src", remote_path="/root/src"),
 )
 def scheduled_task():
     # Import inside the function so it doesn't try to load it globally before mounting

--- a/tests/test_run_cloud.py
+++ b/tests/test_run_cloud.py
@@ -3,7 +3,8 @@ import os
 
 # Add root directory to python path if not already there, though pytest handles it usually
 # but for robust importing of scripts in the root dir we ensure it.
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 
 def test_run_cloud_imports_successfully():
     """
@@ -13,7 +14,9 @@ def test_run_cloud_imports_successfully():
     """
     try:
         import run_cloud
+
         assert run_cloud.app is not None
     except Exception as e:
         import pytest
+
         pytest.fail(f"Importing run_cloud.py failed with an exception: {e}")

--- a/tests/test_run_cloud.py
+++ b/tests/test_run_cloud.py
@@ -1,0 +1,19 @@
+import sys
+import os
+
+# Add root directory to python path if not already there, though pytest handles it usually
+# but for robust importing of scripts in the root dir we ensure it.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+def test_run_cloud_imports_successfully():
+    """
+    Test that run_cloud.py can be imported without throwing any exceptions.
+    This specifically guards against issues like missing attributes in third-party
+    libraries (e.g., modal API changes).
+    """
+    try:
+        import run_cloud
+        assert run_cloud.app is not None
+    except Exception as e:
+        import pytest
+        pytest.fail(f"Importing run_cloud.py failed with an exception: {e}")


### PR DESCRIPTION
Fixes an issue where modal API changed and dropped `modal.Mount`. Instead we're using `add_local_dir` on the `Image` as suggested by modal documentation. Added a pytest specifically to ensure the cloud script is importable, which catches import-level errors for third-party libraries.

---
*PR created automatically by Jules for task [17750709948211760222](https://jules.google.com/task/17750709948211760222) started by @japppie*